### PR TITLE
Add "desc" parameter to glossary_atoz shortcode

### DIFF
--- a/class/shortcode/class-atoz.php
+++ b/class/shortcode/class-atoz.php
@@ -13,78 +13,208 @@
 
 
 /**
- * @copyright 2015-2016 iThoughts Informatique
- * @license https://www.gnu.org/licenses/gpl-3.0.html GPLv3
- */
+  * @copyright 2015-2016 iThoughts Informatique
+  * @license https://www.gnu.org/licenses/gpl-3.0.html GPLv3
+  */
 
 namespace ithoughts\tooltip_glossary\shortcode;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	 status_header( 403 );wp_die("Forbidden");// Exit if accessed directly
+	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( __NAMESPACE__ . '\\AtoZ' ) ) {
-	class AtoZ extends GlossaryList {
+if(!class_exists(__NAMESPACE__."\\AtoZ")){
+	class AtoZ extends GlossaryList{
+        const LIST_MODE_MICROPOST	= 1;
+		const LIST_MODE_WPPOST		= 2;
+
+		const LIST_MODE_NONE		= 1;
+		const LIST_MODE_TIP			= 3;
+		const LIST_MODE_EXCERPT		= 2;
+		const LIST_MODE_FULL		= 4;
+
 		public function __construct() {
-			add_shortcode( 'glossary_atoz', array( $this, 'glossary_atoz' ) );
+			add_shortcode( 'glossary_atoz', array($this, 'glossary_atoz') );
 		}
 
-		public function glossary_atoz( $atts, $content = '' ) {
+		public function glossary_atoz( $atts, $content='' ){
 			$backbone = \ithoughts\tooltip_glossary\Backbone::get_instance();
 
-			$out = $this->init_list_atts( $atts );
-			$data = &$out['data'];
-			$linkdata = &$out['linkdata'];
+			$out = $this->init_list_atts($atts);
+			$data = &$out["data"];
+			$linkdata = &$out["linkdata"];
+            
+            $mode;
+			switch($data["handled"]["desc"]){
+				case 'none':{
+				$mode = self::LIST_MODE_NONE;
+			} break;
+
+				case 'tip':{
+				$mode = self::LIST_MODE_TIP;
+			} break;
+
+				case 'excerpt':{
+				$mode = self::LIST_MODE_EXCERPT;
+			} break;
+
+				case 'full':{
+				$mode = self::LIST_MODE_FULL;
+			} break;
+
+				default:{
+				$mode = self::LIST_MODE_TIP;
+			}
+			}
 
 			// Sanity check the list of letters (if set by user).
-			$alphas = $this->filter_alphas_to_array( isset( $data['handled'] ) && isset( $data['handled']['alpha'] ) && $data['handled']['alpha'] ? $data['handled']['alpha'] : null );
+			$alphas = $this->filter_alphas_to_array(isset($data["handled"]) && isset($data["handled"]["alpha"]) && $data["handled"]["alpha"] ? $data["handled"]["alpha"] : NULL );
 			// Checks for partial listing options (on first letter, or group)
-			$group_ids = $this->filter_groupIds_to_array( isset( $data['handled'] ) && isset( $data['handled']['group'] ) ? $data['handled']['group'] : null );
+			$group_ids = $this->filter_groupIds_to_array(isset($data["handled"]) && isset($data["handled"]["group"]) ? $data["handled"]["group"] : NULL);
 
-			// Fetch
-			$termsInfos = $this->get_microposts( $group_ids,$alphas );
-			$terms = &$termsInfos['terms'];
-			$count = $termsInfos['count'];
+            //$terms;
+			$count;
+            
+            // Define default desc to tips. Will generate tooltips
+			// If no content is required, use microposts. Else, use normal terms
+			if($mode & self::LIST_MODE_MICROPOST){
+				// Add qtip script only if loading tooltips
+				if($mode === self::LIST_MODE_TIP){
+					$backbone->add_script('qtip');
+				}
 
-			if ( ! count( $terms ) ) {
-				return '<p>' . __( 'There are no glossary items.','ithoughts-tooltip-glossary' ) . '</p>';
+				// Fetch microposts
+				$termsInfos = $this->get_microposts($group_ids,$alphas);
+                //$terms = &$termsInfos["terms"];
+			} else {
+				// Fetch full posts
+				$linkdata = apply_filters("ithoughts_tt_gl-split-args", $linkdata);
+				$termsInfos = $this->get_lists_terms($group_ids,$alphas);
+                //$terms = $this->dispatch_per_char($termsInfos["terms"], 0, "WP_Post");
 			}
+            $terms = &$termsInfos["terms"];
+			$count = $termsInfos["count"];
+
+			if( !count($terms) )
+				return '<p>'.__('There are no glossary items.','ithoughts-tooltip-glossary').'</p>';
 
 			$atoz = array();
-			foreach ( $terms as $post ) {
-				$title = $post->post_title;
-				$alpha = strtoupper( \ithoughts\v5_0\Toolbox::unaccent( mb_substr( $title,0,1, 'UTF-8' ) ) );
-				if ( ! preg_match( '/[A-Z]/', $alpha ) ) {
-					$alpha = '#';
-				}
-				$alpha_attribute = $alpha;
-				$alpha_attribute = $alpha_attribute == '#' ? 'other' : $alpha_attribute ;
+            
+            switch($mode) {
+                case self::LIST_MODE_TIP:{
+                    foreach( $terms as $post ) {
+                        $title = $post->post_title;
+                        $alpha = strtoupper( \ithoughts\v5_0\Toolbox::unaccent(mb_substr($title,0,1, "UTF-8")) );
+                        if(!preg_match("/[A-Z]/", $alpha))
+                            $alpha = "#";
+                        $alpha_attribute = $alpha;
+                        $alpha_attribute = $alpha_attribute == "#" ? "other" : $alpha_attribute ;
 
-				$link = apply_filters( 'ithoughts_tt_gl_get_glossary_term_element', $post, null, $linkdata );
-				$item  = '<li class="glossary-item ithoughts-tooltip-glossaryatoz-li atoz-li-' . $alpha_attribute . '">';
-				$item .= $link;
-				$item .= '</li>';
+                        $link = apply_filters("ithoughts_tt_gl_get_glossary_term_element", $post, null, $linkdata);
+                        $item  = '<li class="glossary-item ithoughts-tooltip-glossaryatoz-li atoz-li-' . $alpha_attribute . '">';
+                        $item .= $link;
+                        $item .= '</li>';
 
-				$atoz[ $alpha ][] = $item;
-			}
+                        $atoz[$alpha][] = $item;
+                    }
+                } break;
+                case self::LIST_MODE_FULL:{
+                    foreach( $terms as $post ) {
+                        $title = $post->post_title;
+                        $alpha = strtoupper( \ithoughts\v5_0\Toolbox::unaccent(mb_substr($title,0,1, "UTF-8")) );
+                        if(!preg_match("/[A-Z]/", $alpha))
+                            $alpha = "#";
+                        $alpha_attribute = $alpha;
+                        $alpha_attribute = $alpha_attribute == "#" ? "other" : $alpha_attribute ;
+
+                        $href  = apply_filters( 'ithoughts_tt_gl_term_link',  \ithoughts\v5_0\Toolbox::get_permalink_light($post, "glossary") );
+                        $target = "";
+                        if( $data["options"]["termlinkopt"] != 'none' ){
+                            $linkAttrs["target"] = "_blank";
+                        }
+                        $linkAttrs["href"] = &$href;
+                        $args = \ithoughts\v5_0\Toolbox::concat_attrs( $linkAttrs);
+                        $item  = '<span class="glossary-item ithoughts-tooltip-glossaryatoz-li atoz-li-' . $alpha_attribute . '">';
+                        $link   = '<header class="entry-header"><h5 class="entry-title"><a '.$args.' title="'. $title .'">' . $title . '</a></h5></header>';
+                        $content = '<div class="entry-content clearfix"><p>' . $post->post_content . '</p></div>';
+                        $item .= $link;
+                        $item .= $content;
+                        $item .= '</span><br>';
+
+                        $atoz[$alpha][] = $item;
+                    }                    
+                } break;
+                case self::LIST_MODE_EXCERPT:{
+                    foreach( $terms as $post ) {
+                        $title = $post->post_title;
+                        $alpha = strtoupper( \ithoughts\v5_0\Toolbox::unaccent(mb_substr($title,0,1, "UTF-8")) );
+                        if(!preg_match("/[A-Z]/", $alpha))
+                            $alpha = "#";
+                        $alpha_attribute = $alpha;
+                        $alpha_attribute = $alpha_attribute == "#" ? "other" : $alpha_attribute ;
+
+                        $href  = apply_filters( 'ithoughts_tt_gl_term_link',  \ithoughts\v5_0\Toolbox::get_permalink_light($post, "glossary") );
+                        $target = "";
+                        if( $data["options"]["termlinkopt"] != 'none' ){
+                            $linkAttrs["target"] = "_blank";
+                        }
+                        $linkAttrs["href"] = &$href;
+                        $args = \ithoughts\v5_0\Toolbox::concat_attrs( $linkAttrs);
+                        $item  = '<span class="glossary-item ithoughts-tooltip-glossaryatoz-li atoz-li-' . $alpha_attribute . '">';
+                        $link   = '<header class="entry-header"><h5 class="entry-title"><a '.$args.' title="'. $title .'">' . $title . '</a></h5></header>';
+                        $content = '<div class="entry-content clearfix"><p>' . apply_filters("ithoughts_tt_gl-term-excerpt", $post) . '</p></div>';
+                        $item .= $link;
+                        $item .= $content;
+                        $item .= '</span><br>';
+
+                        $atoz[$alpha][] = $item;
+                    }
+                } break;
+                case self::LIST_MODE_NONE:{ //This part's not working--not sure why
+                    foreach( $terms as $post ) {
+                        $title = $post->post_title;
+                        $alpha = strtoupper( \ithoughts\v5_0\Toolbox::unaccent(mb_substr($title,0,1, "UTF-8")) );
+                        if(!preg_match("/[A-Z]/", $alpha))
+                            $alpha = "#";
+                        $alpha_attribute = $alpha;
+                        $alpha_attribute = $alpha_attribute == "#" ? "other" : $alpha_attribute ;
+
+                        $href  = apply_filters( 'ithoughts_tt_gl_term_link',  \ithoughts\v5_0\Toolbox::get_permalink_light($post, "glossary") );
+                        $target = "";
+                        if( $data["options"]["termlinkopt"] != 'none' ){
+                            $linkAttrs["target"] = "_blank";
+                        }
+                        $linkAttrs["href"] = &$href;
+                        $args = \ithoughts\v5_0\Toolbox::concat_attrs( $linkAttrs);
+                        $item  = '<span class="glossary-item ithoughts-tooltip-glossaryatoz-li atoz-li-' . $alpha_attribute . '">';
+                        $link   = '<a '.$args.'>' . $title . '</a>';
+                        $content = '<br>' . '<span class="glossary-item-desc">' . apply_filters("ithoughts_tt_gl-term-excerpt", $post) . '</span>';
+                        $item .= $link;
+                        $item .= $content;
+                        $item .= '</span>';
+
+                        $atoz[$alpha][] = $item;
+                    }
+                } break;
+            }
 
 			// Menu
 			$menu  = '<ul class="glossary-menu-atoz">';
-			$range = apply_filters( 'ithoughts_tt_gl_atoz_range', array_keys( $atoz ) );
-			foreach ( $range as $alpha ) {
-				$count = count( $atoz[ $alpha ] );
+			$range = apply_filters( 'ithoughts_tt_gl_atoz_range', array_keys($atoz) );
+			foreach( $range as $alpha ) {
+				$count = count( $atoz[$alpha] );
 				$alpha_attribute = $alpha;
-				$alpha_attribute = $alpha_attribute == '#' ? 'other' : $alpha_attribute ;
-				$menu .= '<li class="glossary-menu-item atoz-menu-' . $alpha_attribute . ' itg-atoz-clickable itg-atoz-menu-off" title="' . strtoupper( $alpha ) . '" alt="' . esc_attr__( 'Terms','ithoughts-tooltip-glossary' ) . ': ' . $count . '"  data-alpha="' . $alpha_attribute . '">';
-				$menu .= '<a href="#' . $alpha_attribute . '">' . strtoupper( $alpha ) . '</a></li>';
+				$alpha_attribute = $alpha_attribute == "#" ? "other" : $alpha_attribute ;
+				$menu .= '<li class="glossary-menu-item atoz-menu-' . $alpha_attribute . ' itg-atoz-clickable itg-atoz-menu-off" title="'.strtoupper($alpha).'" alt="' . esc_attr__('Terms','ithoughts-tooltip-glossary') . ': ' . $count . '"  data-alpha="' . $alpha_attribute . '">';
+				$menu .= '<a href="#' . $alpha_attribute . '">' . strtoupper($alpha) . '</a></li>';
 			}
 			$menu .= '</ul>';
 
 			// Items
 			$list = '<div class="itg-glossary-atoz-wrapper">';
-			foreach ( $atoz as $alpha => $items ) {
+			foreach( $atoz as $alpha => $items ) {
 				$alpha_attribute = $alpha;
-				$alpha_attribute = $alpha_attribute == '#' ? 'other' : $alpha_attribute ;
+				$alpha_attribute = $alpha_attribute == "#" ? "other" : $alpha_attribute ;
 				$list .= '<ul class="itg-atoz-items itg-atoz-items-' . $alpha_attribute . ' itg-atoz-items-off">';
 				$list .= implode( '', $items );
 				$list .= '</ul>';
@@ -92,12 +222,12 @@ if ( ! class_exists( __NAMESPACE__ . '\\AtoZ' ) ) {
 			$list .= '</div>';
 
 			$clear    = '<div style="clear: both;"></div>';
-			$data['attributes']['class'] = 'glossary-atoz-wrapper' . ((isset( $data['attributes']['class'] ) && $data['attributes']['class']) ? ' ' . $data['attributes']['class'] : '');
-			$args = \ithoughts\v5_0\Toolbox::concat_attrs( $data['attributes'] );
-			$plsclick = apply_filters( 'ithoughts_tt_gl_please_select', '<div class="ithoughts_tt_gl-please-select"><p>' . __( 'Please select from the menu above', 'ithoughts-tooltip-glossary' ) . '</p></div>' );
+			$data["attributes"]["class"] = "glossary-atoz-wrapper".((isset($data["attributes"]["class"]) && $data["attributes"]["class"]) ? " ".$data["attributes"]["class"] : "");
+			$args = \ithoughts\v5_0\Toolbox::concat_attrs( $data["attributes"]);
+			$plsclick = apply_filters( 'ithoughts_tt_gl_please_select', '<div class="ithoughts_tt_gl-please-select"><p>' . __('Please select from the menu above', 'ithoughts-tooltip-glossary' ) . '</p></div>' );
 			// Global variable that tells WP to print related js files.
-			$backbone->add_scripts( array( 'qtip', 'atoz' ) );
-			return '<div ' . $args . '>' . $menu . $clear . $plsclick . $clear . $list . '</div>';
+            $backbone->add_script('atoz');
+			return '<div '.$args.'>' . $menu . $clear . $plsclick . $clear . $list . '</div>';
 		} // glossary_atoz
 	} // atoz
-}// End if().
+}

--- a/class/shortcode/class-atoz.php
+++ b/class/shortcode/class-atoz.php
@@ -20,11 +20,11 @@
 namespace ithoughts\tooltip_glossary\shortcode;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+     status_header( 403 );wp_die("Forbidden");// Exit if accessed directly
 }
 
-if(!class_exists(__NAMESPACE__."\\AtoZ")){
-	class AtoZ extends GlossaryList{
+if ( !class_exists(__NAMESPACE__."\\AtoZ") ) {
+	class AtoZ extends GlossaryList {
         const LIST_MODE_MICROPOST	= 1;
 		const LIST_MODE_WPPOST		= 2;
 
@@ -34,13 +34,13 @@ if(!class_exists(__NAMESPACE__."\\AtoZ")){
 		const LIST_MODE_FULL		= 4;
 
 		public function __construct() {
-			add_shortcode( 'glossary_atoz', array($this, 'glossary_atoz') );
+			add_shortcode( 'glossary_atoz', array( $this, 'glossary_atoz' ) );
 		}
 
-		public function glossary_atoz( $atts, $content='' ){
+		public function glossary_atoz( $atts, $content = '' ) {
 			$backbone = \ithoughts\tooltip_glossary\Backbone::get_instance();
 
-			$out = $this->init_list_atts($atts);
+			$out = $this->init_list_atts( $atts );
 			$data = &$out["data"];
 			$linkdata = &$out["linkdata"];
             
@@ -68,9 +68,9 @@ if(!class_exists(__NAMESPACE__."\\AtoZ")){
 			}
 
 			// Sanity check the list of letters (if set by user).
-			$alphas = $this->filter_alphas_to_array(isset($data["handled"]) && isset($data["handled"]["alpha"]) && $data["handled"]["alpha"] ? $data["handled"]["alpha"] : NULL );
+			$alphas = $this->filter_alphas_to_array( isset( $data['handled']) && isset( $data['handled']['alpha'] ) && $data['handled']['alpha'] ? $data['handled']['alpha'] : null );
 			// Checks for partial listing options (on first letter, or group)
-			$group_ids = $this->filter_groupIds_to_array(isset($data["handled"]) && isset($data["handled"]["group"]) ? $data["handled"]["group"] : NULL);
+			$group_ids = $this->filter_groupIds_to_array(isset($data["handled"]) && isset($data["handled"]["group"]) ? $data["handled"]["group"] : null);
 
             //$terms;
 			$count;
@@ -200,21 +200,21 @@ if(!class_exists(__NAMESPACE__."\\AtoZ")){
 
 			// Menu
 			$menu  = '<ul class="glossary-menu-atoz">';
-			$range = apply_filters( 'ithoughts_tt_gl_atoz_range', array_keys($atoz) );
-			foreach( $range as $alpha ) {
-				$count = count( $atoz[$alpha] );
+			$range = apply_filters( 'ithoughts_tt_gl_atoz_range', array_keys( $atoz ) );
+			foreach ( $range as $alpha ) {
+				$count = count( $atoz[ $alpha ] );
 				$alpha_attribute = $alpha;
-				$alpha_attribute = $alpha_attribute == "#" ? "other" : $alpha_attribute ;
-				$menu .= '<li class="glossary-menu-item atoz-menu-' . $alpha_attribute . ' itg-atoz-clickable itg-atoz-menu-off" title="'.strtoupper($alpha).'" alt="' . esc_attr__('Terms','ithoughts-tooltip-glossary') . ': ' . $count . '"  data-alpha="' . $alpha_attribute . '">';
+				$alpha_attribute = $alpha_attribute == '#' ? 'other' : $alpha_attribute ;
+				$menu .= '<li class="glossary-menu-item atoz-menu-' . $alpha_attribute . ' itg-atoz-clickable itg-atoz-menu-off" title="' . strtoupper( $alpha ) . '" alt="' . esc_attr__( 'Terms','ithoughts-tooltip-glossary' ) . ': ' . $count . '"  data-alpha="' . $alpha_attribute . '">';
 				$menu .= '<a href="#' . $alpha_attribute . '">' . strtoupper($alpha) . '</a></li>';
 			}
 			$menu .= '</ul>';
 
 			// Items
 			$list = '<div class="itg-glossary-atoz-wrapper">';
-			foreach( $atoz as $alpha => $items ) {
+			foreach ( $atoz as $alpha => $items ) {
 				$alpha_attribute = $alpha;
-				$alpha_attribute = $alpha_attribute == "#" ? "other" : $alpha_attribute ;
+				$alpha_attribute = $alpha_attribute == '#' ? 'other' : $alpha_attribute ;
 				$list .= '<ul class="itg-atoz-items itg-atoz-items-' . $alpha_attribute . ' itg-atoz-items-off">';
 				$list .= implode( '', $items );
 				$list .= '</ul>';
@@ -222,12 +222,12 @@ if(!class_exists(__NAMESPACE__."\\AtoZ")){
 			$list .= '</div>';
 
 			$clear    = '<div style="clear: both;"></div>';
-			$data["attributes"]["class"] = "glossary-atoz-wrapper".((isset($data["attributes"]["class"]) && $data["attributes"]["class"]) ? " ".$data["attributes"]["class"] : "");
+			$data['attributes']['class'] = 'glossary-atoz-wrapper'. ( (isset( $data['attributes']['class']) && $data['attributes']['class']) ? ' '.$data['attributes']['class'] : '');
 			$args = \ithoughts\v5_0\Toolbox::concat_attrs( $data["attributes"]);
 			$plsclick = apply_filters( 'ithoughts_tt_gl_please_select', '<div class="ithoughts_tt_gl-please-select"><p>' . __('Please select from the menu above', 'ithoughts-tooltip-glossary' ) . '</p></div>' );
 			// Global variable that tells WP to print related js files.
-            $backbone->add_script('atoz');
-			return '<div '.$args.'>' . $menu . $clear . $plsclick . $clear . $list . '</div>';
+            $backbone->add_script( 'atoz' );
+			return '<div ' . $args . '>' . $menu . $clear . $plsclick . $clear . $list . '</div>';
 		} // glossary_atoz
 	} // atoz
 }

--- a/class/shortcode/class-atoz.php
+++ b/class/shortcode/class-atoz.php
@@ -13,9 +13,9 @@
 
 
 /**
-  * @copyright 2015-2016 iThoughts Informatique
-  * @license https://www.gnu.org/licenses/gpl-3.0.html GPLv3
-  */
+ * @copyright 2015-2016 iThoughts Informatique
+ * @license https://www.gnu.org/licenses/gpl-3.0.html GPLv3
+ */
 
 namespace ithoughts\tooltip_glossary\shortcode;
 
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
      status_header( 403 );wp_die("Forbidden");// Exit if accessed directly
 }
 
-if ( !class_exists(__NAMESPACE__."\\AtoZ") ) {
+if ( ! class_exists( __NAMESPACE__ . '\\AtoZ' ) ) {
 	class AtoZ extends GlossaryList {
         const LIST_MODE_MICROPOST	= 1;
 		const LIST_MODE_WPPOST		= 2;
@@ -41,8 +41,8 @@ if ( !class_exists(__NAMESPACE__."\\AtoZ") ) {
 			$backbone = \ithoughts\tooltip_glossary\Backbone::get_instance();
 
 			$out = $this->init_list_atts( $atts );
-			$data = &$out["data"];
-			$linkdata = &$out["linkdata"];
+			$data = &$out['data'];
+			$linkdata = &$out['linkdata'];
             
             $mode;
 			switch($data["handled"]["desc"]){
@@ -68,9 +68,9 @@ if ( !class_exists(__NAMESPACE__."\\AtoZ") ) {
 			}
 
 			// Sanity check the list of letters (if set by user).
-			$alphas = $this->filter_alphas_to_array( isset( $data['handled']) && isset( $data['handled']['alpha'] ) && $data['handled']['alpha'] ? $data['handled']['alpha'] : null );
+			$alphas = $this->filter_alphas_to_array( isset( $data['handled'] ) && isset( $data['handled']['alpha'] ) && $data['handled']['alpha'] ? $data['handled']['alpha'] : null );
 			// Checks for partial listing options (on first letter, or group)
-			$group_ids = $this->filter_groupIds_to_array(isset($data["handled"]) && isset($data["handled"]["group"]) ? $data["handled"]["group"] : null);
+			$group_ids = $this->filter_groupIds_to_array(isset($data['handled']) && isset($data['handled']['group']) ? $data['handled']['group'] : null);
 
             //$terms;
 			$count;
@@ -222,9 +222,9 @@ if ( !class_exists(__NAMESPACE__."\\AtoZ") ) {
 			$list .= '</div>';
 
 			$clear    = '<div style="clear: both;"></div>';
-			$data['attributes']['class'] = 'glossary-atoz-wrapper'. ( (isset( $data['attributes']['class']) && $data['attributes']['class']) ? ' '.$data['attributes']['class'] : '');
-			$args = \ithoughts\v5_0\Toolbox::concat_attrs( $data["attributes"]);
-			$plsclick = apply_filters( 'ithoughts_tt_gl_please_select', '<div class="ithoughts_tt_gl-please-select"><p>' . __('Please select from the menu above', 'ithoughts-tooltip-glossary' ) . '</p></div>' );
+			$data['attributes']['class'] = 'glossary-atoz-wrapper' . ( (isset( $data['attributes']['class'] ) && $data['attributes']['class']) ? ' ' . $data['attributes']['class'] : '');
+			$args = \ithoughts\v5_0\Toolbox::concat_attrs( $data['attributes'] );
+			$plsclick = apply_filters( 'ithoughts_tt_gl_please_select', '<div class="ithoughts_tt_gl-please-select"><p>' . __( 'Please select from the menu above', 'ithoughts-tooltip-glossary' ) . '</p></div>' );
 			// Global variable that tells WP to print related js files.
             $backbone->add_script( 'atoz' );
 			return '<div ' . $args . '>' . $menu . $clear . $plsclick . $clear . $list . '</div>';


### PR DESCRIPTION
The default is desc = "tip", which matches the behavior before. Additional parameters desc="excerpt" and desc="full" are functional and match the behavior for the glossary_term_list shortcode. However, the parameter desc = "none" is not working--not sure why.

Also, added some html tags to entry header and entry content to make it easier to format the entries.